### PR TITLE
Added Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@ _testmain.go
 
 *.vdi
 
-/workspace/src/github.com/darkcrux/go-ceph-rest-api/go-ceph-rest-api
+/workspace/src/github.com/darkcrux/go-ceph-rest-api/build
 /workspace/src/github.com/AcalephStorage
 /workspace/src/github.com/gorilla
-
+/workspace/bin
+/workspace/pkg

--- a/provision/roles/go/tasks/main.yml
+++ b/provision/roles/go/tasks/main.yml
@@ -16,4 +16,4 @@
     state: present
   with_items:
     - export GOPATH=/vagrant/workspace
-    - export PATH=$PATH:/usr/local/go/bin
+    - export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin

--- a/workspace/src/github.com/darkcrux/go-ceph-rest-api/Makefile
+++ b/workspace/src/github.com/darkcrux/go-ceph-rest-api/Makefile
@@ -1,0 +1,52 @@
+APP_NAME = go-ceph-rest-api
+VERSION = latest
+
+all: clean build
+
+clean:
+	@echo "--> Cleaning build"
+	@go clean -i
+	@rm -rf ./build
+
+prepare:
+	@mkdir -p build/bin/linux-amd64
+	@mkdir -p build/test
+	@mkdir -p build/doc
+	@mkdir -p build/tar
+
+deps:
+	@echo "--> Getting dependecies"
+	@go get -v ./...
+
+format:
+	@echo "--> Formatting source code"
+	@go fmt ./...
+
+test: prepare deps format
+	@echo "--> Testing application"
+	@go test -v -outputdir build/test ./...
+
+build: test
+	@echo "--> Building local application"
+	@go build -o build/bin/linux-amd64/${VERSION}/${APP_NAME} -v .
+
+install: build
+	@echo "--> Installing application"
+	@go install
+
+package: build
+	@echo "--> Packaging application"
+	@tar cfz build/tar/${APP_NAME}-${VERSION}-linux-amd64.tar.gz -C build/bin/linux-amd64/${VERSION} ${APP_NAME}
+
+release: package
+ifeq ($(VERSION) , latest)
+	@echo "--> Removing Latest Version"
+	@curl -s -X DELETE -u ${ACCESS_KEY} https://api.bintray.com/packages/darkcrux/generic/${APP_NAME}/versions/${VERSION}
+	@echo
+endif
+	@echo "--> Releasing version: ${VERSION}"
+	@curl -s -T "build/tar/${APP_NAME}-${VERSION}-linux-amd64.tar.gz" -u "${ACCESS_KEY}" "https://api.bintray.com/content/darkcrux/generic/${APP_NAME}/${VERSION}/${APP_NAME}-${VERSION}-linux-amd64.tar.gz"
+	@echo "... linux-amd64"
+	@echo "--> Publishing version ${VERSION}"
+	@curl -s -X POST -u ${ACCESS_KEY} https://api.bintray.com/content/darkcrux/generic/${APP_NAME}/${VERSION}/publish
+	@echo 


### PR DESCRIPTION
Make now handles the build. Targets are:
- clean
- prepare
- deps
- format
- test
- build
- install
- package
- release

Generally, just run `make` to run tests and build. To install the
binary, run `make install`. This will install the binary to $GOPATH/bin.

Also run the provisioning again since there are changes to add
$GOPATH/bin the $PATH.

This resolves #6 
